### PR TITLE
clarify doc string for CallParameters::host_id

### DIFF
--- a/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/expanded.rs
@@ -5,7 +5,7 @@ pub struct CallParameters {
     pub service_id: String,
     /// Id of the service creator.
     pub service_creator_peer_id: String,
-    /// Id of the host which run this service.
+    /// Public key of the peer which run this service.
     pub host_id: String,
     /// Id of the particle which execution resulted a call this service.
     pub particle_id: String,

--- a/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/expanded.rs
@@ -5,7 +5,7 @@ pub struct CallParameters {
     pub service_id: String,
     /// Id of the service creator.
     pub service_creator_peer_id: String,
-    /// PeerId of the peer which run this service.
+    /// PeerId of the peer who hosts this service.
     pub host_id: String,
     /// Id of the particle which execution resulted a call this service.
     pub particle_id: String,

--- a/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/expanded.rs
@@ -5,7 +5,7 @@ pub struct CallParameters {
     pub service_id: String,
     /// Id of the service creator.
     pub service_creator_peer_id: String,
-    /// Public key of the peer which run this service.
+    /// PeerId of the peer which run this service.
     pub host_id: String,
     /// Id of the particle which execution resulted a call this service.
     pub particle_id: String,

--- a/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/marine.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/marine.rs
@@ -8,7 +8,7 @@ pub struct CallParameters {
     /// Id of the service creator.
     pub service_creator_peer_id: String,
 
-    /// Public key of the peer which run this service.
+    /// PeerId of the peer which run this service.
     pub host_id: String,
 
     /// Id of the particle which execution resulted a call this service.

--- a/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/marine.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/marine.rs
@@ -8,7 +8,7 @@ pub struct CallParameters {
     /// Id of the service creator.
     pub service_creator_peer_id: String,
 
-    /// Id of the host which run this service.
+    /// Public key of the peer which run this service.
     pub host_id: String,
 
     /// Id of the particle which execution resulted a call this service.

--- a/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/marine.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/marine.rs
@@ -8,7 +8,7 @@ pub struct CallParameters {
     /// Id of the service creator.
     pub service_creator_peer_id: String,
 
-    /// PeerId of the peer which run this service.
+    /// PeerId of the peer who hosts this service.
     pub host_id: String,
 
     /// Id of the particle which execution resulted a call this service.

--- a/sdk/src/call_parameters.rs
+++ b/sdk/src/call_parameters.rs
@@ -42,7 +42,7 @@ pub struct CallParameters {
     /// Id of the service creator.
     pub service_creator_peer_id: String,
 
-    /// Public key of the peer which run this service.
+    /// PeerId of the peer which run this service.
     pub host_id: String,
 
     /// Id of the particle which execution resulted a call this service.

--- a/sdk/src/call_parameters.rs
+++ b/sdk/src/call_parameters.rs
@@ -42,7 +42,7 @@ pub struct CallParameters {
     /// Id of the service creator.
     pub service_creator_peer_id: String,
 
-    /// Id of the host which run this service.
+    /// Public key of the peer which run this service.
     pub host_id: String,
 
     /// Id of the particle which execution resulted a call this service.

--- a/sdk/src/call_parameters.rs
+++ b/sdk/src/call_parameters.rs
@@ -42,7 +42,7 @@ pub struct CallParameters {
     /// Id of the service creator.
     pub service_creator_peer_id: String,
 
-    /// PeerId of the peer which run this service.
+    /// PeerId of the peer who hosts this service.
     pub host_id: String,
 
     /// Id of the particle which execution resulted a call this service.


### PR DESCRIPTION
As stated in the issue #37, the doc string confuses users, so proposed change made by this PR.