### PR TITLE
Remove serde version lock on 1.0.118

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
  "itertools 0.9.0",
  "log",
  "marine-module-interface",
- "marine-rs-sdk 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.6.11",
  "marine-rs-sdk-main 0.6.10",
  "marine-runtime",
  "marine-utils",
@@ -756,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "marine-macro"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
- "marine-macro-impl 0.6.11",
+ "marine-macro-impl 0.6.12",
 ]
 
 [[package]]
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "marine-macro-impl"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "marine-macro-testing-utils",
  "pretty_assertions",
@@ -835,17 +835,6 @@ dependencies = [
 [[package]]
 name = "marine-rs-sdk"
 version = "0.6.11"
-dependencies = [
- "marine-macro 0.6.11",
- "marine-rs-sdk-main 0.6.11",
- "marine-timestamp-macro 0.6.11",
- "serde",
- "trybuild",
-]
-
-[[package]]
-name = "marine-rs-sdk"
-version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9157bae63a4bbdd7a29984f6ded08f8ed72991b83ca3bdd59d2f889fa8b8ea02"
 dependencies = [
@@ -853,6 +842,17 @@ dependencies = [
  "marine-rs-sdk-main 0.6.10",
  "marine-timestamp-macro 0.6.10",
  "serde",
+]
+
+[[package]]
+name = "marine-rs-sdk"
+version = "0.6.12"
+dependencies = [
+ "marine-macro 0.6.12",
+ "marine-rs-sdk-main 0.6.12",
+ "marine-timestamp-macro 0.6.12",
+ "serde",
+ "trybuild",
 ]
 
 [[package]]
@@ -868,11 +868,11 @@ dependencies = [
 
 [[package]]
 name = "marine-rs-sdk-main"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "lazy_static",
  "log",
- "marine-macro 0.6.11",
+ "marine-macro 0.6.12",
  "serde",
  "simple_logger",
 ]
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "marine-timestamp-macro"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "chrono",
  "quote",

--- a/crates/main/Cargo.toml
+++ b/crates/main/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 marine-macro = { path = "../marine-macro", version = "=0.6.11" }
 
 log = { version = "0.4.8", features = ["std"] }
-serde = "=1.0.118"
+serde = "1.0.118"
 
 [dev-dependencies]
 simple_logger = "1.6.0" # used in doc test

--- a/crates/main/Cargo.toml
+++ b/crates/main/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marine-rs-sdk-main"
-version = "0.6.11"  # remember to update html_root_url
+version = "0.6.12"  # remember to update html_root_url
 edition = "2018"
 description = "Contains logger, allocators and several other modules for marine-rs-sdk"
 documentation = "https://docs.rs/marine-rs-sdk-main"
@@ -19,7 +19,7 @@ crate-type = ["rlib"]
 doctest = false
 
 [dependencies]
-marine-macro = { path = "../marine-macro", version = "=0.6.11" }
+marine-macro = { path = "../marine-macro", version = "=0.6.12" }
 
 log = { version = "0.4.8", features = ["std"] }
 serde = "1.0.118"

--- a/crates/main/src/lib.rs
+++ b/crates/main/src/lib.rs
@@ -19,7 +19,7 @@
 
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::needless_doctest_main)]
-#![doc(html_root_url = "https://docs.rs/marine-rs-sdk-main/0.6.11")]
+#![doc(html_root_url = "https://docs.rs/marine-rs-sdk-main/0.6.12")]
 #![deny(
     dead_code,
     nonstandard_style,

--- a/crates/marine-macro-impl/Cargo.toml
+++ b/crates/marine-macro-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marine-macro-impl"
-version = "0.6.11"  # remember to update html_root_url
+version = "0.6.12"  # remember to update html_root_url
 edition = "2018"
 description = "Implementation of the `#[marine]` macro"
 documentation = "https://docs.rs/fluence/marine-macro-impl"

--- a/crates/marine-macro-impl/Cargo.toml
+++ b/crates/marine-macro-impl/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 [dependencies]
 quote = "1.0.9"
 proc-macro2 = "1.0.24"
-serde = { version = "=1.0.118", features = ["derive"] }
+serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.56"
 syn = { version = '1.0.64', features = ['full', "extra-traits"] }
 uuid = { version = "0.8.2", features = ["v4"] }

--- a/crates/marine-macro-impl/src/lib.rs
+++ b/crates/marine-macro-impl/src/lib.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#![doc(html_root_url = "https://docs.rs/marine-macro-impl/0.6.11")]
+#![doc(html_root_url = "https://docs.rs/marine-macro-impl/0.6.12")]
 #![deny(
     dead_code,
     nonstandard_style,

--- a/crates/marine-macro/Cargo.toml
+++ b/crates/marine-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marine-macro"
-version = "0.6.11"  # remember to update html_root_url
+version = "0.6.12"  # remember to update html_root_url
 edition = "2018"
 description = "Definition of the `#[marine]` macro"
 documentation = "https://docs.rs/fluence/marine-macro"
@@ -18,4 +18,4 @@ proc-macro = true
 doctest = false
 
 [dependencies]
-marine-macro-impl = { path = "../marine-macro-impl", version = "=0.6.11" }
+marine-macro-impl = { path = "../marine-macro-impl", version = "=0.6.12" }

--- a/crates/marine-macro/src/lib.rs
+++ b/crates/marine-macro/src/lib.rs
@@ -50,7 +50,7 @@
 //!
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/marine-macro/0.6.11")]
+#![doc(html_root_url = "https://docs.rs/marine-macro/0.6.12")]
 #![deny(
     dead_code,
     nonstandard_style,

--- a/crates/timestamp-macro/Cargo.toml
+++ b/crates/timestamp-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marine-timestamp-macro"
-version = "0.6.11"  # remember to update html_root_url
+version = "0.6.12"  # remember to update html_root_url
 edition = "2018"
 description = "Definition of the `#[build_timestamp]` macro"
 documentation = "https://docs.rs/fluence/marine-timestamp-macro"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marine-rs-sdk"
-version = "0.6.11"  # remember to update html_root_url
+version = "0.6.12"  # remember to update html_root_url
 description = "Fluence backend SDK for developing backend applications for the Fluence network"
 documentation = "https://docs.rs/fluence"
 repository = "https://github.com/fluencelabs/marine-rs-sdk"
@@ -18,9 +18,9 @@ path = "src/lib.rs"
 doctest = false
 
 [dependencies]
-marine-macro = { path = "../crates/marine-macro", version = "=0.6.11" }
-marine-rs-sdk-main = { path = "../crates/main", version = "=0.6.11" }
-marine-timestamp-macro = { path = "../crates/timestamp-macro", version = "=0.6.11" }
+marine-macro = { path = "../crates/marine-macro", version = "=0.6.12" }
+marine-rs-sdk-main = { path = "../crates/main", version = "=0.6.12" }
+marine-timestamp-macro = { path = "../crates/timestamp-macro", version = "=0.6.12" }
 
 serde = { version = "1.0.118", features = ["derive"]}
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -55,7 +55,7 @@
 //!     pub fn curl_get(url: String) -> String;
 //! }
 //! ```
-#![doc(html_root_url = "https://docs.rs/sdk/0.6.11")]
+#![doc(html_root_url = "https://docs.rs/sdk/0.6.12")]
 #![deny(
     dead_code,
     nonstandard_style,


### PR DESCRIPTION
`serde` version was strictly locked at `1.0.118` due to a breaking change in `1.0.119`. Now `marine-rs-sdk `compiles with `serde 1.0.130` and it is possible to remove the strict requirement. This will avoid conflicts with crates that require `serde` newer than `1.0.118`.