### PR TITLE
fix compilation for rustc 1.57.0-nightly

### DIFF
--- a/crates/marine-macro-impl/src/ast_types.rs
+++ b/crates/marine-macro-impl/src/ast_types.rs
@@ -18,25 +18,25 @@ use crate::parsed_type::ParsedType;
 
 #[derive(Clone)]
 pub(crate) struct AstFnArgument {
-    pub name: String,
-    pub ty: ParsedType,
+    pub(crate) name: String,
+    pub(crate) ty: ParsedType,
 }
 
 #[derive(Clone)]
 pub(crate) struct AstFnSignature {
-    pub visibility: syn::Visibility,
-    pub name: String,
-    pub arguments: Vec<AstFnArgument>,
+    pub(crate) visibility: syn::Visibility,
+    pub(crate) name: String,
+    pub(crate) arguments: Vec<AstFnArgument>,
     // only one or zero return values are supported now,
     // waiting for adding multi-value support in Wasmer
-    pub output_type: Option<ParsedType>,
+    pub(crate) output_type: Option<ParsedType>,
 }
 
 #[derive(Clone)]
 pub(crate) struct AstRecord {
-    pub name: String,
-    pub fields: AstRecordFields,
-    pub original: syn::ItemStruct,
+    pub(crate) name: String,
+    pub(crate) fields: AstRecordFields,
+    pub(crate) original: syn::ItemStruct,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -55,15 +55,15 @@ pub(crate) enum AstRecordFields {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct AstRecordField {
     /// Name of the field. Can be `None` for tuples.
-    pub name: Option<String>,
-    pub ty: ParsedType,
+    pub(crate) name: Option<String>,
+    pub(crate) ty: ParsedType,
 }
 
 #[derive(Clone)]
 pub(crate) struct AstExternFn {
-    pub link_name: Option<String>,
+    pub(crate) link_name: Option<String>,
     // only imports are possible here
-    pub signature: AstFnSignature,
+    pub(crate) signature: AstFnSignature,
 }
 
 #[derive(Clone)]
@@ -75,8 +75,8 @@ pub(crate) struct AstExternMod {
 
 #[derive(Clone)]
 pub(crate) struct AstFn {
-    pub signature: AstFnSignature,
-    pub original: syn::ItemFn,
+    pub(crate) signature: AstFnSignature,
+    pub(crate) original: syn::ItemFn,
 }
 
 #[derive(Clone)]

--- a/crates/marine-macro-impl/src/ast_types.rs
+++ b/crates/marine-macro-impl/src/ast_types.rs
@@ -68,10 +68,9 @@ pub(crate) struct AstExternFn {
 
 #[derive(Clone)]
 pub(crate) struct AstExternMod {
-    pub namespace: String,
+    pub(crate) namespace: String,
     // only imports are possible here
-    pub imports: Vec<AstExternFn>,
-    pub original: syn::ItemForeignMod,
+    pub(crate) imports: Vec<AstExternFn>,
 }
 
 #[derive(Clone)]

--- a/crates/marine-macro-impl/src/parse_macro_input/item_foreign_mod.rs
+++ b/crates/marine-macro-impl/src/parse_macro_input/item_foreign_mod.rs
@@ -39,7 +39,6 @@ impl ParseMacroInput for syn::ItemForeignMod {
         let extern_mod_item = ast_types::AstExternMod {
             namespace,
             imports,
-            original: self,
         };
         Ok(MarineAst::ExternMod(extern_mod_item))
     }

--- a/crates/marine-macro-impl/src/parse_macro_input/item_foreign_mod.rs
+++ b/crates/marine-macro-impl/src/parse_macro_input/item_foreign_mod.rs
@@ -36,10 +36,7 @@ impl ParseMacroInput for syn::ItemForeignMod {
         let imports = extract_import_functions(&self)?;
         check_imports(imports.iter().zip(self.items.iter().map(|i| i.span())))?;
 
-        let extern_mod_item = ast_types::AstExternMod {
-            namespace,
-            imports,
-        };
+        let extern_mod_item = ast_types::AstExternMod { namespace, imports };
         Ok(MarineAst::ExternMod(extern_mod_item))
     }
 }


### PR DESCRIPTION
Just a compilation hotfix. Also changed `pub`->`pub(crate)` in the touched struct, as it makes no sense to have just `pub`.