### PR TITLE
Add rust-toolchain file and use new setup rust action

### DIFF
--- a/.github/workflows/marine-rs-sdk.yml
+++ b/.github/workflows/marine-rs-sdk.yml
@@ -10,47 +10,39 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
-jobs:
-  build:
-    name: "Build and test"
-    runs-on: builder
+env:
+  RUST_TEST_THREADS: 1
 
-    env:
-      RUST_BACKTRACE: 1
-      RUST_TEST_THREADS: 1
-      CARGO_TERM_COLOR: always
+jobs:
+  marine-rs-sdk:
+    name: "Run tests"
+    runs-on: builder
 
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-wasi
-          components: rustfmt, clippy
+      - name: Setup rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: "Cache rust"
-        uses: Swatinem/rust-cache@v1
-
-      - name: "cargo fmt"
+      - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
-      - name: "cargo build"
+      - name: Run cargo build
         env:
           CARGO_BUILD_TARGET: wasm32-wasi
         run: cargo build
 
-      - name: "cargo check"
+      - name: Run cargo check
         run: cargo check -v --all-features
 
-      - name: "Run marine-macro-impl"
+      - name: Run marine-macro-impl tests
         run: cargo test
         working-directory: crates/marine-macro-impl
 
-      - name: "cargo test"
+      - name: Run cargo test
         run: cargo test --release --all-features --no-fail-fast
 
-      - name: "cargo clippy"
+      - name: Run cargo clippy
         env:
           CARGO_BUILD_TARGET: wasm32-wasi
         run: cargo clippy

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -7,42 +7,22 @@ jobs:
   npm-publish:
     name: "Publish release"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      ### Prepare cargo & toolchains
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          toolchain: nightly
-          command: update
-          args: --aggressive
+      - name: Setup rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - run: cargo update --aggressive
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get --yes --force-yes install jq
 
       - name: Install cargo-workspaces
-        run: cargo install cargo-workspaces || true
+        run: cargo install cargo-workspaces
 
-      ### === Rust package release ===
       - name: Login to crates.io
         run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
 
@@ -57,7 +37,6 @@ jobs:
       - name: Publish to crates.io
         run: cargo ws publish --no-git-commit --from-git --skip-published --yes
 
-      ### Create a release
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "stable"
-targets = [ "x86_64-unknown-linux-gnu", "wasm32-wasi" ]
+targets = [ "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-wasi" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+targets = [ "x86_64-unknown-linux-gnu", "wasm32-wasi" ]


### PR DESCRIPTION
- Added `rust-toolchain.toml` file so rust toolchain is the same when running rust locally and with CI.
No need to specify channel or components in github workflow file now.


- Changed `Setup rust toolchain` step to use different action. Old one is not maintained anymore. Beware that it sets these env variables by default:
    ```
    CARGO_INCREMENTAL=0
    CARGO_PROFILE_DEV_DEBUG=0
    CARGO_TERM_COLOR=always
    RUST_BACKTRACE=short
    RUSTFLAGS=-D warnings
    ```