### PR TITLE
fix(ABI): use correct empty string/vector representation 

### DIFF
--- a/crates/marine-macro-impl/src/parsed_type/fn_prolog.rs
+++ b/crates/marine-macro-impl/src/parsed_type/fn_prolog.rs
@@ -131,7 +131,7 @@ fn generate_type_lifting_prolog(
                         // so we ensure that an empty string is correctly represented.
                         match #size {
                             0 => String::default(),
-                            n => String::from_raw_parts(#ptr as _, #size as _, #size as _)
+                            _ => String::from_raw_parts(#ptr as _, #size as _, #size as _)
                         };
                 },
                 ParsedType::Vector(ty, _) => {

--- a/crates/marine-macro-impl/src/parsed_type/foreign_mod_epilog.rs
+++ b/crates/marine-macro-impl/src/parsed_type/foreign_mod_epilog.rs
@@ -50,11 +50,14 @@ impl ForeignModEpilogGlueCodeGenerator for Option<ParsedType> {
                 return result as _;
             },
             Some(ParsedType::Utf8String(_)) => quote! {
-                String::from_raw_parts(
-                    marine_rs_sdk::internal::get_result_ptr() as _,
-                    marine_rs_sdk::internal::get_result_size() as _,
-                    marine_rs_sdk::internal::get_result_size() as _
-                )
+                let ptr = marine_rs_sdk::internal::get_result_ptr();
+                let size = marine_rs_sdk::internal::get_result_size();
+                // Empty string has a non-zero buffer address in Rust,
+                // so we ensure that an empty string is correctly represented.
+                match size {
+                    0 => String::default(),
+                    n => String::from_raw_parts(ptr as _, size as _, size as _)
+                }
             },
             Some(ParsedType::Vector(ty, _)) => {
                 let generated_der_name = "__m_generated_vec_deserializer";

--- a/crates/marine-macro-impl/src/parsed_type/foreign_mod_epilog.rs
+++ b/crates/marine-macro-impl/src/parsed_type/foreign_mod_epilog.rs
@@ -56,7 +56,7 @@ impl ForeignModEpilogGlueCodeGenerator for Option<ParsedType> {
                 // so we ensure that an empty string is correctly represented.
                 match size {
                     0 => String::default(),
-                    n => String::from_raw_parts(ptr as _, size as _, size as _)
+                    _ => String::from_raw_parts(ptr as _, size as _, size as _)
                 }
             },
             Some(ParsedType::Vector(ty, _)) => {

--- a/crates/marine-macro-impl/src/parsed_type/vector_ser_der.rs
+++ b/crates/marine-macro-impl/src/parsed_type/vector_ser_der.rs
@@ -85,7 +85,12 @@ pub(crate) fn generate_vector_der(
         ParsedType::Record(record_name, _) => record_der(record_name),
         _ => {
             quote! {
-                Vec::from_raw_parts(offset as _, size as _, size as _)
+                // Empty vector has a non-zero buffer address in Rust,
+                // so we ensure that an empty vector is correctly represented.
+                match size {
+                    0 => Vec::default(),
+                    n => Vec::from_raw_parts(offset as _, size as _, size as _)
+                }
             }
         }
     };

--- a/crates/marine-macro-impl/src/parsed_type/vector_ser_der.rs
+++ b/crates/marine-macro-impl/src/parsed_type/vector_ser_der.rs
@@ -89,7 +89,7 @@ pub(crate) fn generate_vector_der(
                 // so we ensure that an empty vector is correctly represented.
                 match size {
                     0 => Vec::default(),
-                    n => Vec::from_raw_parts(offset as _, size as _, size as _)
+                    _ => Vec::from_raw_parts(offset as _, size as _, size as _)
                 }
             }
         }

--- a/crates/marine-macro-impl/src/parsed_type/vector_ser_der/der.rs
+++ b/crates/marine-macro-impl/src/parsed_type/vector_ser_der/der.rs
@@ -27,7 +27,12 @@ pub(super) fn string_der() -> proc_macro2::TokenStream {
 
         while let Some(offset) = arg.next() {
             let size = arg.next().unwrap();
-            let value = String::from_raw_parts(offset as _, size as _, size as _);
+            // Empty string has a non-zero buffer address in Rust,
+            // so we ensure that an empty string is correctly represented.
+            let value = match size {
+                0 => String::default(),
+                n => String::from_raw_parts(offset as _, size as _, size as _)
+            };
             result.push(value);
         }
 

--- a/crates/marine-macro-impl/src/parsed_type/vector_ser_der/der.rs
+++ b/crates/marine-macro-impl/src/parsed_type/vector_ser_der/der.rs
@@ -31,7 +31,7 @@ pub(super) fn string_der() -> proc_macro2::TokenStream {
             // so we ensure that an empty string is correctly represented.
             let value = match size {
                 0 => String::default(),
-                n => String::from_raw_parts(offset as _, size as _, size as _)
+                _ => String::from_raw_parts(offset as _, size as _, size as _)
             };
             result.push(value);
         }

--- a/crates/marine-macro-impl/src/token_stream_generator/record_generator/field_values_builder.rs
+++ b/crates/marine-macro-impl/src/token_stream_generator/record_generator/field_values_builder.rs
@@ -248,8 +248,12 @@ impl FieldValuesBuilder {
                     raw_record[#value_id + 6],
                     raw_record[#value_id + 7],
                 ]);
-
-                String::from_raw_parts(offset as _, size as _, size as _)
+                // Empty string has a non-zero buffer address in Rust,
+                // so we ensure that an empty string is correctly represented.
+                match size {
+                    0 => String::default(),
+                    n => String::from_raw_parts(offset as _, size as _, size as _)
+                }
             };
         };
 

--- a/crates/marine-macro-impl/src/token_stream_generator/record_generator/field_values_builder.rs
+++ b/crates/marine-macro-impl/src/token_stream_generator/record_generator/field_values_builder.rs
@@ -252,7 +252,7 @@ impl FieldValuesBuilder {
                 // so we ensure that an empty string is correctly represented.
                 match size {
                     0 => String::default(),
-                    n => String::from_raw_parts(offset as _, size as _, size as _)
+                    _ => String::from_raw_parts(offset as _, size as _, size as _)
                 }
             };
         };

--- a/crates/marine-macro-impl/tests/generation_tests/exports/arrays/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/exports/arrays/expanded.rs
@@ -20,7 +20,10 @@ pub unsafe fn __m_generated_wrapper_func_inner_arrays_1(arg_0: u32, arg_1: u32) 
                     offset: u32,
                     size: u32
                 ) -> Vec<u8> {
-                    Vec::from_raw_parts(offset as _, size as _, size as _)
+                    match size {
+                        0 => Vec::default(),
+                        n => Vec::from_raw_parts(offset as _, size as _, size as _)
+                    }
                 }
                 let vec_passing_size = 2;
                 let mut arg: Vec<u32> =

--- a/crates/marine-macro-impl/tests/generation_tests/exports/arrays/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/exports/arrays/expanded.rs
@@ -22,7 +22,7 @@ pub unsafe fn __m_generated_wrapper_func_inner_arrays_1(arg_0: u32, arg_1: u32) 
                 ) -> Vec<u8> {
                     match size {
                         0 => Vec::default(),
-                        n => Vec::from_raw_parts(offset as _, size as _, size as _)
+                        _ => Vec::from_raw_parts(offset as _, size as _, size as _)
                     }
                 }
                 let vec_passing_size = 2;

--- a/crates/marine-macro-impl/tests/generation_tests/exports/basic_types/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/exports/basic_types/expanded.rs
@@ -50,7 +50,10 @@ pub unsafe fn __m_generated_wrapper_func_all_types(
         n => String::from_raw_parts(arg_10 as _, arg_11 as _, arg_11 as _)
     };
     unsafe fn __m_generated_vec_deserializer_12(offset: u32, size: u32) -> Vec<u8> {
-        Vec::from_raw_parts(offset as _, size as _, size as _)
+        match size {
+            0 => Vec::default(),
+            n => Vec::from_raw_parts(offset as _, size as _, size as _)
+        }
     }
     let converted_arg_12 = __m_generated_vec_deserializer_12(arg_12 as _, arg_13 as _);
     let result = all_types(

--- a/crates/marine-macro-impl/tests/generation_tests/exports/basic_types/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/exports/basic_types/expanded.rs
@@ -45,7 +45,10 @@ pub unsafe fn __m_generated_wrapper_func_all_types(
     let converted_arg_7 = arg_7 as _;
     let converted_arg_8 = arg_8 as _;
     let converted_arg_9 = arg_9 as _;
-    let converted_arg_10 = String::from_raw_parts(arg_10 as _, arg_11 as _, arg_11 as _);
+    let converted_arg_10 = match arg_11 {
+        0 => String::default(),
+        n => String::from_raw_parts(arg_10 as _, arg_11 as _, arg_11 as _)
+    };
     unsafe fn __m_generated_vec_deserializer_12(offset: u32, size: u32) -> Vec<u8> {
         Vec::from_raw_parts(offset as _, size as _, size as _)
     }

--- a/crates/marine-macro-impl/tests/generation_tests/exports/basic_types/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/exports/basic_types/expanded.rs
@@ -47,12 +47,12 @@ pub unsafe fn __m_generated_wrapper_func_all_types(
     let converted_arg_9 = arg_9 as _;
     let converted_arg_10 = match arg_11 {
         0 => String::default(),
-        n => String::from_raw_parts(arg_10 as _, arg_11 as _, arg_11 as _)
+        _ => String::from_raw_parts(arg_10 as _, arg_11 as _, arg_11 as _)
     };
     unsafe fn __m_generated_vec_deserializer_12(offset: u32, size: u32) -> Vec<u8> {
         match size {
             0 => Vec::default(),
-            n => Vec::from_raw_parts(offset as _, size as _, size as _)
+            _ => Vec::from_raw_parts(offset as _, size as _, size as _)
         }
     }
     let converted_arg_12 = __m_generated_vec_deserializer_12(arg_12 as _, arg_13 as _);

--- a/crates/marine-macro-impl/tests/generation_tests/exports/refs/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/exports/refs/expanded.rs
@@ -16,7 +16,10 @@ pub unsafe fn __m_generated_wrapper_func_test_array_refs(arg_0: u32, arg_1: u32)
             let mut result = Vec::with_capacity(arg.len() / 2);
             while let Some(offset) = arg.next() {
                 let size = arg.next().unwrap();
-                let value = String::from_raw_parts(offset as _, size as _, size as _);
+                let value = match size {
+                    0 => String::default(),
+                    n => String::from_raw_parts(offset as _, size as _, size as _)
+                };
                 result.push(value);
             }
             result

--- a/crates/marine-macro-impl/tests/generation_tests/exports/refs/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/exports/refs/expanded.rs
@@ -18,7 +18,7 @@ pub unsafe fn __m_generated_wrapper_func_test_array_refs(arg_0: u32, arg_1: u32)
                 let size = arg.next().unwrap();
                 let value = match size {
                     0 => String::default(),
-                    n => String::from_raw_parts(offset as _, size as _, size as _)
+                    _ => String::from_raw_parts(offset as _, size as _, size as _)
                 };
                 result.push(value);
             }

--- a/crates/marine-macro-impl/tests/generation_tests/imports/arrays/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/imports/arrays/expanded.rs
@@ -78,7 +78,10 @@ pub fn inner_arrays_1(arg_0: Vec<Vec<Vec<Vec<u8>>>>) -> Vec<Vec<Vec<Vec<u8>>>> {
                         offset: u32,
                         size: u32
                     ) -> Vec<u8> {
-                        Vec::from_raw_parts(offset as _, size as _, size as _)
+                        match size {
+                            0 => Vec::default(),
+                            n => Vec::from_raw_parts(offset as _, size as _, size as _)
+                        }
                     }
                     let vec_passing_size = 2;
                     let mut arg: Vec<u32> = Vec::from_raw_parts(

--- a/crates/marine-macro-impl/tests/generation_tests/imports/arrays/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/imports/arrays/expanded.rs
@@ -80,7 +80,7 @@ pub fn inner_arrays_1(arg_0: Vec<Vec<Vec<Vec<u8>>>>) -> Vec<Vec<Vec<Vec<u8>>>> {
                     ) -> Vec<u8> {
                         match size {
                             0 => Vec::default(),
-                            n => Vec::from_raw_parts(offset as _, size as _, size as _)
+                            _ => Vec::from_raw_parts(offset as _, size as _, size as _)
                         }
                     }
                     let vec_passing_size = 2;

--- a/crates/marine-macro-impl/tests/generation_tests/imports/basic_types/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/imports/basic_types/expanded.rs
@@ -78,7 +78,10 @@ pub fn all_types(
         );
         std::mem::ManuallyDrop::drop(&mut arg_10);
         unsafe fn __m_generated_vec_deserializer(offset: u32, size: u32) -> Vec<u8> {
-            Vec::from_raw_parts(offset as _, size as _, size as _)
+            match size {
+                0 => Vec::default(),
+                n => Vec::from_raw_parts(offset as _, size as _, size as _)
+            }
         }
         __m_generated_vec_deserializer(
             marine_rs_sdk::internal::get_result_ptr() as _,

--- a/crates/marine-macro-impl/tests/generation_tests/imports/basic_types/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/imports/basic_types/expanded.rs
@@ -80,7 +80,7 @@ pub fn all_types(
         unsafe fn __m_generated_vec_deserializer(offset: u32, size: u32) -> Vec<u8> {
             match size {
                 0 => Vec::default(),
-                n => Vec::from_raw_parts(offset as _, size as _, size as _)
+                _ => Vec::from_raw_parts(offset as _, size as _, size as _)
             }
         }
         __m_generated_vec_deserializer(

--- a/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/expanded.rs
@@ -83,7 +83,10 @@ impl CallParameters {
                 raw_record[0usize + 6],
                 raw_record[0usize + 7],
             ]);
-            String::from_raw_parts(offset as _, size as _, size as _)
+            match size {
+                0 => String::default(),
+                n => String::from_raw_parts(offset as _, size as _, size as _)
+            }
         };
         let field_1 = unsafe {
             let offset = u32::from_le_bytes([
@@ -98,7 +101,10 @@ impl CallParameters {
                 raw_record[8usize + 6],
                 raw_record[8usize + 7],
             ]);
-            String::from_raw_parts(offset as _, size as _, size as _)
+            match size {
+                0 => String::default(),
+                n => String::from_raw_parts(offset as _, size as _, size as _)
+            }
         };
         let field_2 = unsafe {
             let offset = u32::from_le_bytes([
@@ -113,7 +119,10 @@ impl CallParameters {
                 raw_record[16usize + 6],
                 raw_record[16usize + 7],
             ]);
-            String::from_raw_parts(offset as _, size as _, size as _)
+            match size {
+                0 => String::default(),
+                n => String::from_raw_parts(offset as _, size as _, size as _)
+            }
         };
         let field_3 = unsafe {
             let offset = u32::from_le_bytes([
@@ -128,7 +137,10 @@ impl CallParameters {
                 raw_record[24usize + 6],
                 raw_record[24usize + 7],
             ]);
-            String::from_raw_parts(offset as _, size as _, size as _)
+            match size {
+                0 => String::default(),
+                n => String::from_raw_parts(offset as _, size as _, size as _)
+            }
         };
         let field_4 = unsafe {
             let offset = u32::from_le_bytes([
@@ -143,7 +155,10 @@ impl CallParameters {
                 raw_record[32usize + 6],
                 raw_record[32usize + 7],
             ]);
-            String::from_raw_parts(offset as _, size as _, size as _)
+            match size {
+                0 => String::default(),
+                n => String::from_raw_parts(offset as _, size as _, size as _)
+            }
         };
         unsafe fn __m_generated_vec_deserializer_40(
             offset: u32,

--- a/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/expanded.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/records/call_parameters/expanded.rs
@@ -85,7 +85,7 @@ impl CallParameters {
             ]);
             match size {
                 0 => String::default(),
-                n => String::from_raw_parts(offset as _, size as _, size as _)
+                _ => String::from_raw_parts(offset as _, size as _, size as _)
             }
         };
         let field_1 = unsafe {
@@ -103,7 +103,7 @@ impl CallParameters {
             ]);
             match size {
                 0 => String::default(),
-                n => String::from_raw_parts(offset as _, size as _, size as _)
+                _ => String::from_raw_parts(offset as _, size as _, size as _)
             }
         };
         let field_2 = unsafe {
@@ -121,7 +121,7 @@ impl CallParameters {
             ]);
             match size {
                 0 => String::default(),
-                n => String::from_raw_parts(offset as _, size as _, size as _)
+                _ => String::from_raw_parts(offset as _, size as _, size as _)
             }
         };
         let field_3 = unsafe {
@@ -139,7 +139,7 @@ impl CallParameters {
             ]);
             match size {
                 0 => String::default(),
-                n => String::from_raw_parts(offset as _, size as _, size as _)
+                _ => String::from_raw_parts(offset as _, size as _, size as _)
             }
         };
         let field_4 = unsafe {
@@ -157,7 +157,7 @@ impl CallParameters {
             ]);
             match size {
                 0 => String::default(),
-                n => String::from_raw_parts(offset as _, size as _, size as _)
+                _ => String::from_raw_parts(offset as _, size as _, size as _)
             }
         };
         unsafe fn __m_generated_vec_deserializer_40(


### PR DESCRIPTION
The example looks like this:
There is a function exported from a module:
```rust
#[marine]
pub fn greeting(name: String) {
    println!("Some(name) = {:?}", Some(name));
}
```
And what it prints when given an empty and non-empty string:
```
1> c greeting greeting ""
Some(name) = None
result: null
 elapsed time: 2.486875ms

2> c greeting greeting "1"
Some(name) = Some("1")
result: null
 elapsed time: 2.290292ms
```
The correct behavior will be to print `Some(name) = Some("")` in the first call. 

The bug happens because marine-runtime represents an empty string as `0x0` buffer address and `marine-rs-sdk` builds the string from it using `String::from_raw_parts`, which does not check anything and copies values to the String's fields.  The problem is that the correct empty string representation in Rust has a non-zero buffer address (`0x1` found experimentally, but it is not a documented value). It interferes with Rust's optimization for `Option` tags, where the `String`'s object buffer address is also used to mark it as `Some`.

The solution is to check the strings provided to/returned from `#[marine]` functions and build any empty strings using `String::default()`. The same applies to `Vec`, so it is also fixed in this PR.