### PR TITLE
feat!: introduce host import API versions

### DIFF
--- a/crates/call-parameters/src/lib.rs
+++ b/crates/call-parameters/src/lib.rs
@@ -136,7 +136,7 @@ pub fn get_call_parameters() -> CallParameters {
 }
 
 #[cfg(all(feature = "marine-abi", target_arch = "wasm32"))]
-#[link(wasm_import_module = "host")]
+#[link(wasm_import_module = "__marine_host_api_v1")]
 #[allow(improper_ctypes)]
 extern "C" {
     // returns serialized current call parameters

--- a/crates/main/src/logger.rs
+++ b/crates/main/src/logger.rs
@@ -238,6 +238,7 @@ pub fn log_utf8_string(level: i32, target: i32, msg_ptr: i32, msg_size: i32) {
     println!("[{}] {} {}", level, target, msg);
 }
 
+#[allow(unused_doc_comments)]
 /// TODO: mark `log_utf8_string_impl` as #[wasm_bindgen], so it is polyfilled by bindgen
 /// log_utf8_string should be provided directly by a host.
 #[cfg(all(feature = "marine-abi", target_arch = "wasm32"))]

--- a/crates/main/src/logger.rs
+++ b/crates/main/src/logger.rs
@@ -241,7 +241,7 @@ pub fn log_utf8_string(level: i32, target: i32, msg_ptr: i32, msg_size: i32) {
 /// TODO: mark `log_utf8_string_impl` as #[wasm_bindgen], so it is polyfilled by bindgen
 /// log_utf8_string should be provided directly by a host.
 #[cfg(all(feature = "marine-abi", target_arch = "wasm32"))]
-#[link(wasm_import_module = "host")]
+#[link(wasm_import_module = "__marine_host_api_v1")]
 extern "C" {
     // Writes a byte string of size bytes that starts from ptr to a logger
     #[link_name = "log_utf8_string"]

--- a/crates/marine-macro-impl/src/lib.rs
+++ b/crates/marine-macro-impl/src/lib.rs
@@ -49,3 +49,5 @@ pub use token_stream_generator::GENERATED_GLOBAL_PREFIX;
 pub use wasm_type::RustType;
 
 pub const GENERATED_SECTION_PREFIX_FCE: &str = "__fce_generated_section__";
+pub const MARINE_HOST_API_NAMESPACE_PREFIX: &str = "__marine_host_api_v";
+pub const MARINE_HOST_API_VERSION: u32 = 1;

--- a/crates/marine-macro-impl/src/parse_macro_input/item_foreign_mod.rs
+++ b/crates/marine-macro-impl/src/parse_macro_input/item_foreign_mod.rs
@@ -52,7 +52,7 @@ fn check_foreign_section(foreign_mod: &syn::ItemForeignMod) -> Result<()> {
 }
 
 /// Tries to find and parse wasm module name from
-///   #[link(wasm_import_module = "host")]
+/// #[module_import("module_name")] or #[host_import]
 fn parse_wasm_import_module(foreign_mod: &syn::ItemForeignMod) -> Vec<String> {
     foreign_mod
         .attrs

--- a/crates/marine-macro-impl/src/parse_macro_input/item_foreign_mod.rs
+++ b/crates/marine-macro-impl/src/parse_macro_input/item_foreign_mod.rs
@@ -88,7 +88,7 @@ fn try_extract_namespace(
     mut attr: Vec<String>,
     foreign_mod: &syn::ItemForeignMod,
 ) -> Result<String> {
-    if attr.len() == 0 {
+    if attr.is_empty() {
         return syn_error!(
             foreign_mod.span(),
             "import module name should be defined by either '#[host_import]' or '#[module_import(\"module_name\")]' attributes"

--- a/crates/marine-macro-impl/tests/generation_tests/imports/arrays/marine.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/imports/arrays/marine.rs
@@ -1,4 +1,4 @@
-#[link(wasm_import_module = "test")]
+#[module_import("test")]
 extern "C" {
     pub fn inner_arrays_1(arg: Vec<Vec<Vec<Vec<u8>>>>) -> Vec<Vec<Vec<Vec<u8>>>>;
 }

--- a/crates/marine-macro-impl/tests/generation_tests/imports/basic_types/marine.rs
+++ b/crates/marine-macro-impl/tests/generation_tests/imports/basic_types/marine.rs
@@ -1,4 +1,4 @@
-#[link(wasm_import_module = "test")]
+#[module_import("test")]
 extern "C" {
     pub fn all_types(
         arg_0: i8,

--- a/tests/compilation_tests/import_functions/arrays.rs
+++ b/tests/compilation_tests/import_functions/arrays.rs
@@ -12,7 +12,7 @@ pub struct TestRecord {
 }
 
 #[marine]
-#[link(wasm_import_module = "arrays_passing_effector")]
+#[module_import("arrays_passing_effector")]
 extern "C" {
     pub fn inner_arrays_1(arg: Vec<Vec<Vec<Vec<u8>>>>) -> Vec<Vec<Vec<Vec<u8>>>>;
 

--- a/tests/compilation_tests/import_functions/arrays_out_inner_refs.rs
+++ b/tests/compilation_tests/import_functions/arrays_out_inner_refs.rs
@@ -5,7 +5,7 @@ use marine_rs_sdk::marine;
 pub fn main() {}
 
 #[marine]
-#[link(wasm_import_module = "arrays_passing_effector")]
+#[module_import("arrays_passing_effector")]
 extern "C" {
     #[marine]
     pub fn func_1() -> &String;

--- a/tests/compilation_tests/import_functions/basic_ref_types.rs
+++ b/tests/compilation_tests/import_functions/basic_ref_types.rs
@@ -5,7 +5,7 @@ use marine_rs_sdk::marine;
 fn main() {}
 
 #[marine]
-#[link(wasm_import_module = "arguments_passing_effector")]
+#[module_import("arrays_passing_effector")]
 extern "C" {
     pub fn all_ref_types(
         arg_0: &i8,

--- a/tests/compilation_tests/import_functions/basic_types.rs
+++ b/tests/compilation_tests/import_functions/basic_types.rs
@@ -5,7 +5,7 @@ use marine_rs_sdk::marine;
 fn main() {}
 
 #[marine]
-#[link(wasm_import_module = "arguments_passing_effector")]
+#[module_import("arguments_passing_effector")]
 extern "C" {
     pub fn all_types(
         arg_0: i8,

--- a/tests/compilation_tests/import_functions/improper_types.rs
+++ b/tests/compilation_tests/import_functions/improper_types.rs
@@ -5,7 +5,7 @@ use marine_rs_sdk::marine;
 pub fn main() {}
 
 #[marine]
-#[link(wasm_import_module = "arguments_passing_effector")]
+#[module_import("arrays_passing_effector")]
 extern "C" {
     #[marine]
     fn test(_arg_1: Box<i32>);

--- a/tests/compilation_tests/import_functions/ref_arrays.rs
+++ b/tests/compilation_tests/import_functions/ref_arrays.rs
@@ -12,7 +12,7 @@ pub struct TestRecord {
 }
 
 #[marine]
-#[link(wasm_import_module = "arrays_passing_effector")]
+#[module_import("arrays_passing_effector")]
 extern "C" {
     pub fn inner_arrays_1(arg: &Vec<Vec<Vec<Vec<u8>>>>) -> Vec<Vec<Vec<Vec<u8>>>>;
     pub fn inner_arrays_2(arg: &Vec<&Vec<Vec<Vec<u8>>>>) -> Vec<Vec<Vec<Vec<u8>>>>;

--- a/tests/compilation_tests/import_functions/ref_basic_types.rs
+++ b/tests/compilation_tests/import_functions/ref_basic_types.rs
@@ -5,7 +5,7 @@ use marine_rs_sdk::marine;
 fn main() {}
 
 #[marine]
-#[link(wasm_import_module = "arguments_passing_effector")]
+#[module_import("arrays_passing_effector")]
 extern "C" {
     pub fn all_types(
         arg_0: &i8,

--- a/tests/compilation_tests/records/struct_with_private_fields.rs
+++ b/tests/compilation_tests/records/struct_with_private_fields.rs
@@ -14,7 +14,7 @@ struct StructWithPrivateFields {
 fn export_func(_field: StructWithPrivateFields) { }
 
 #[marine]
-#[link(wasm_import_module = "record_module")]
+#[module_import("record_module")]
 extern "C" {
     fn import_func(arg: &StructWithPrivateFields) -> StructWithPrivateFields;
 }


### PR DESCRIPTION
This PR changes format for host imports: previously "host" namespace was used for them, now it will be "__marine_host_api_v\d+", where "__marine_host_api_v1" is the current one, and "host" is translated to ""__marine_host_api_v0"